### PR TITLE
Bugfix/create bot

### DIFF
--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1,9 +1,10 @@
 import axios from 'axios';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+const AUTH_API_URL = import.meta.env.VITE_AUTH_API_URL || 'http://localhost:3001';
+const K8S_API_URL = import.meta.env.VITE_K8S_API_URL || 'http://localhost:3003';
 
-export const api = axios.create({
-  baseURL: API_URL,
+export const authApi = axios.create({
+  baseURL: AUTH_API_URL,
   timeout: 30000,
   withCredentials: true,
   headers: {
@@ -11,7 +12,27 @@ export const api = axios.create({
   },
 });
 
-api.interceptors.response.use(
+export const k8sApi = axios.create({
+  baseURL: K8S_API_URL,
+  timeout: 30000,
+  withCredentials: true,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+authApi.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem('user');
+      window.location.href = '/login';
+    }
+    return Promise.reject(error);
+  }
+);
+
+k8sApi.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {

--- a/client/src/services/authService.ts
+++ b/client/src/services/authService.ts
@@ -1,4 +1,4 @@
-import { api } from './api';
+import { authApi } from './api';
 
 export interface User {
   id: string;
@@ -19,7 +19,7 @@ export interface LoginResponse {
 
 export const authService = {
   async register(email: string, password: string): Promise<RegisterResponse> {
-    const response = await api.post<RegisterResponse>('/api/auth/register', {
+    const response = await authApi.post<RegisterResponse>('/api/auth/register', {
       email,
       password,
     });
@@ -27,7 +27,7 @@ export const authService = {
   },
 
   async login(email: string, password: string): Promise<LoginResponse> {
-    const response = await api.post<LoginResponse>('/api/auth/login', {
+    const response = await authApi.post<LoginResponse>('/api/auth/login', {
       email,
       password,
     });
@@ -35,11 +35,11 @@ export const authService = {
   },
 
   async getCurrentUser(): Promise<{ user: User }> {
-    const response = await api.get<{ user: User }>('/api/auth/me');
+    const response = await authApi.get<{ user: User }>('/api/auth/me');
     return response.data;
   },
 
   async logout(): Promise<void> {
-    await api.post('/api/auth/logout');
+    await authApi.post('/api/auth/logout');
   },
 };

--- a/client/src/services/botService.ts
+++ b/client/src/services/botService.ts
@@ -44,7 +44,24 @@ export const botService = {
   },
 
   async createBot(data: CreateBotRequest): Promise<Bot> {
-    const response = await api.post<{ bot: Bot }>('/api/bots', data);
+    const formData = new FormData();
+
+    formData.append('name', data.name);
+    formData.append('language', data.language);
+    formData.append('version', data.version);
+
+    if (data.zipFile) {
+      formData.append('zipFile', data.zipFile);
+    }
+
+    formData.append('envVars', JSON.stringify(data.envVars));
+
+    const response = await api.post<{ bot: Bot }>('/api/bots', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+
     return response.data.bot;
   },
 

--- a/client/src/services/botService.ts
+++ b/client/src/services/botService.ts
@@ -1,4 +1,4 @@
-import { api } from './api';
+import { k8sApi } from './api';
 
 export interface Bot {
   id: string;
@@ -34,12 +34,12 @@ export interface BotStats {
 
 export const botService = {
   async getBots(): Promise<Bot[]> {
-    const response = await api.get<{ bots: Bot[] }>('/api/bots');
+    const response = await k8sApi.get<{ bots: Bot[] }>('/api/v1/bots');
     return response.data.bots;
   },
 
   async getBot(id: string): Promise<Bot> {
-    const response = await api.get<{ bot: Bot }>(`/api/bots/${id}`);
+    const response = await k8sApi.get<{ bot: Bot }>(`/api/v1/bots/${id}`);
     return response.data.bot;
   },
 
@@ -56,7 +56,7 @@ export const botService = {
 
     formData.append('envVars', JSON.stringify(data.envVars));
 
-    const response = await api.post<{ bot: Bot }>('/api/bots', formData, {
+    const response = await k8sApi.post<{ bot: Bot }>('/api/v1/bots', formData, {
       headers: {
         'Content-Type': 'multipart/form-data',
       },
@@ -66,36 +66,36 @@ export const botService = {
   },
 
   async updateBot(id: string, data: Partial<CreateBotRequest>): Promise<Bot> {
-    const response = await api.patch<{ bot: Bot }>(`/api/bots/${id}`, data);
+    const response = await k8sApi.patch<{ bot: Bot }>(`/api/v1/bots/${id}`, data);
     return response.data.bot;
   },
 
   async deleteBot(id: string): Promise<void> {
-    await api.delete(`/api/bots/${id}`);
+    await k8sApi.delete(`/api/v1/bots/${id}`);
   },
 
   async startBot(id: string): Promise<Bot> {
-    const response = await api.post<{ bot: Bot }>(`/api/bots/${id}/start`);
+    const response = await k8sApi.post<{ bot: Bot }>(`/api/v1/bots/${id}/start`);
     return response.data.bot;
   },
 
   async stopBot(id: string): Promise<Bot> {
-    const response = await api.post<{ bot: Bot }>(`/api/bots/${id}/stop`);
+    const response = await k8sApi.post<{ bot: Bot }>(`/api/v1/bots/${id}/stop`);
     return response.data.bot;
   },
 
   async restartBot(id: string): Promise<Bot> {
-    const response = await api.post<{ bot: Bot }>(`/api/bots/${id}/restart`);
+    const response = await k8sApi.post<{ bot: Bot }>(`/api/v1/bots/${id}/restart`);
     return response.data.bot;
   },
 
   async getStats(): Promise<BotStats> {
-    const response = await api.get<BotStats>('/api/bots/stats');
+    const response = await k8sApi.get<BotStats>('/api/v1/bots/stats');
     return response.data;
   },
 
   async getLogs(id: string, lines: number = 100): Promise<string[]> {
-    const response = await api.get<{ logs: string[] }>(`/api/bots/${id}/logs?lines=${lines}`);
+    const response = await k8sApi.get<{ logs: string[] }>(`/api/v1/bots/${id}/logs?lines=${lines}`);
     return response.data.logs;
   },
 };


### PR DESCRIPTION
This pull request refactors the API service layer to support multiple backend endpoints, separating authentication and Kubernetes-related operations. It introduces dedicated Axios instances for each API, updates service modules to use the appropriate instance, and modifies bot creation to handle file uploads using multipart form data.

**API service layer refactor:**

* Split the original `api` Axios instance in `api.ts` into two separate instances: `authApi` for authentication endpoints and `k8sApi` for Kubernetes-related endpoints, each with its own base URL and response interceptors.

**Authentication service updates:**

* Updated `authService.ts` to use the new `authApi` instance for all authentication-related requests, replacing references to the old `api` instance. [[1]](diffhunk://#diff-f39521c47c7e3882fb93682ed2f7d9585f4c04ac3d626b886b0c8258a41a234fL1-R1) [[2]](diffhunk://#diff-f39521c47c7e3882fb93682ed2f7d9585f4c04ac3d626b886b0c8258a41a234fL22-R43)

**Bot service updates:**

* Updated `botService.ts` to use the new `k8sApi` instance for all bot-related operations, including bot management, stats, and logs. All endpoint paths were changed to `/api/v1/bots` for consistency with the Kubernetes API. [[1]](diffhunk://#diff-eecb2d0cb4a091fb9df4865d4fc2788b272ceff3b6bc0f9a5a3eae7ce1190330L1-R1) [[2]](diffhunk://#diff-eecb2d0cb4a091fb9df4865d4fc2788b272ceff3b6bc0f9a5a3eae7ce1190330L37-R98)

**Bot creation enhancement:**

* Refactored bot creation in `botService.ts` to use `FormData`, enabling support for file uploads (e.g., a zipped bot package), and set the request header to `multipart/form-data`.