### PR TITLE
Add multipart file upload

### DIFF
--- a/k8s-service/package-lock.json
+++ b/k8s-service/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@fastify/cors": "^10.0.2",
+        "@fastify/multipart": "^9.2.1",
         "axios": "^1.7.9",
         "dotenv": "^16.4.1",
         "fastify": "^5.2.2"
@@ -55,6 +56,12 @@
         "fast-uri": "^3.0.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
+    },
     "node_modules/@fastify/cors": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-10.1.0.tgz",
@@ -74,6 +81,22 @@
         "fastify-plugin": "^5.0.0",
         "mnemonist": "0.40.0"
       }
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.1.0.tgz",
+      "integrity": "sha512-lCVONBQINyNhM6LLezB6+2afusgEYR4G8xenMsfe+AT+iZ7Ca6upM5Ha8UkZuYSnuMw3GWl/BiPXnLMi/gSxuQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@fastify/error": {
       "version": "4.2.0",
@@ -143,6 +166,29 @@
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/multipart": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-9.2.1.tgz",
+      "integrity": "sha512-U4221XDMfzCUtfzsyV1/PkR4MNgKI0158vUUyn/oF2Tl6RxMc+N7XYLr5fZXQiEC+Fmw5zFaTjxsTGTgtDtK+g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@fastify/deepmerge": "^3.0.0",
+        "@fastify/error": "^4.0.0",
+        "fastify-plugin": "^5.0.0",
+        "secure-json-parse": "^4.0.0"
       }
     },
     "node_modules/@fastify/proxy-addr": {

--- a/k8s-service/package.json
+++ b/k8s-service/package.json
@@ -16,10 +16,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "fastify": "^5.2.2",
     "@fastify/cors": "^10.0.2",
+    "@fastify/multipart": "^9.2.1",
+    "axios": "^1.7.9",
     "dotenv": "^16.4.1",
-    "axios": "^1.7.9"
+    "fastify": "^5.2.2"
   },
   "devDependencies": {
     "@types/node": "^20.11.5",

--- a/k8s-service/src/controllers/botController.ts
+++ b/k8s-service/src/controllers/botController.ts
@@ -9,12 +9,6 @@ export const deployBot = async (
   reply: FastifyReply
 ) => {
   try {
-    const data = await request.file();
-
-    if (!data) {
-      return reply.status(400).send({ error: 'No file uploaded' });
-    }
-
     const parts = await request.parts();
     const fields: Record<string, string> = {};
     let zipFile: Buffer | null = null;

--- a/k8s-service/src/controllers/botController.ts
+++ b/k8s-service/src/controllers/botController.ts
@@ -1,15 +1,58 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { BotDeploymentService } from '../services/botDeploymentService';
-import { BotDeploymentRequest, BotScaleRequest } from '../types/bot';
+import { BotScaleRequest, EnvVar } from '../types/bot';
 
 const botService = new BotDeploymentService();
 
 export const deployBot = async (
-  request: FastifyRequest<{ Body: BotDeploymentRequest }>,
+  request: FastifyRequest,
   reply: FastifyReply
 ) => {
   try {
-    const bot = await botService.deployBot(request.body);
+    const data = await request.file();
+
+    if (!data) {
+      return reply.status(400).send({ error: 'No file uploaded' });
+    }
+
+    const parts = await request.parts();
+    const fields: Record<string, string> = {};
+    let zipFile: Buffer | null = null;
+
+    for await (const part of parts) {
+      if (part.type === 'file') {
+        if (part.fieldname === 'zipFile') {
+          zipFile = await part.toBuffer();
+        }
+      } else {
+        fields[part.fieldname] = part.value as string;
+      }
+    }
+
+    if (!fields.name || !fields.language || !fields.version) {
+      return reply.status(400).send({
+        error: 'Missing required fields',
+        message: 'name, language, and version are required'
+      });
+    }
+
+    let envVars: EnvVar[] = [];
+    if (fields.envVars) {
+      try {
+        envVars = JSON.parse(fields.envVars);
+      } catch {
+        envVars = [];
+      }
+    }
+
+    const bot = await botService.deployBot({
+      name: fields.name,
+      language: fields.language,
+      version: fields.version,
+      env: envVars,
+      image: `${fields.language}:${fields.version}`,
+    });
+
     reply.status(201).send(bot);
   } catch (error: any) {
     reply.status(400).send({ error: 'Failed to deploy bot', message: error.message });

--- a/k8s-service/src/index.ts
+++ b/k8s-service/src/index.ts
@@ -1,5 +1,6 @@
 import Fastify from 'fastify';
 import cors from '@fastify/cors';
+import multipart from '@fastify/multipart';
 import { config } from './config/env';
 import botRoutes from './routes/botRoutes';
 import namespaceRoutes from './routes/namespaceRoutes';
@@ -21,6 +22,12 @@ async function start() {
     await fastify.register(cors, {
       origin: true,
       credentials: true,
+    });
+
+    await fastify.register(multipart, {
+      limits: {
+        fileSize: 100 * 1024 * 1024,
+      },
     });
 
     fastify.get('/health', async (request, reply) => {

--- a/k8s-service/src/types/bot.ts
+++ b/k8s-service/src/types/bot.ts
@@ -13,30 +13,25 @@ export enum BotStatus {
   UNKNOWN = 'unknown',
 }
 
+export interface EnvVar {
+  key: string;
+  value: string;
+}
+
 export interface BotConfig {
   name: string;
-  type: BotType;
+  language: string;
+  version: string;
   image: string;
-  token: string;
-  replicas?: number;
-  env?: Record<string, string>;
-  resources?: {
-    limits?: {
-      cpu?: string;
-      memory?: string;
-    };
-    requests?: {
-      cpu?: string;
-      memory?: string;
-    };
-  };
+  env?: EnvVar[];
   port?: number;
 }
 
 export interface Bot {
   id: string;
   name: string;
-  type: BotType;
+  language: string;
+  version: string;
   status: BotStatus;
   namespace: string;
   image: string;
@@ -52,21 +47,9 @@ export interface Bot {
 
 export interface BotDeploymentRequest {
   name: string;
-  type: BotType;
-  image: string;
-  token: string;
-  replicas?: number;
-  env?: Record<string, string>;
-  resources?: {
-    limits?: {
-      cpu?: string;
-      memory?: string;
-    };
-    requests?: {
-      cpu?: string;
-      memory?: string;
-    };
-  };
+  language: string;
+  version: string;
+  envVars: string;
 }
 
 export interface BotScaleRequest {


### PR DESCRIPTION
This pull request introduces support for handling multipart form data for bot deployment, refactors bot configuration to use language and version fields instead of type, and improves environment variable handling. The changes also update dependencies to support multipart uploads and simplify deployment manifest creation.

**Multipart form and dependency updates:**

* Added `@fastify/multipart` and related dependencies to `package.json` and `package-lock.json` to enable multipart form data handling for file uploads. (`k8s-service/package.json`, `k8s-service/package-lock.json`) [[1]](diffhunk://#diff-c271bd648bb50ce0efd85e7ea4308e4ee78e509dbd67a96108579863f1536678L19-R23) [[2]](diffhunk://#diff-6fb867650165a29c2ac522b579990f193f6ffd1dd2564918156622347e2cf516R13) [[3]](diffhunk://#diff-6fb867650165a29c2ac522b579990f193f6ffd1dd2564918156622347e2cf516R59-R64) [[4]](diffhunk://#diff-6fb867650165a29c2ac522b579990f193f6ffd1dd2564918156622347e2cf516R85-R100) [[5]](diffhunk://#diff-6fb867650165a29c2ac522b579990f193f6ffd1dd2564918156622347e2cf516R171-R193)
* Registered `@fastify/multipart` middleware in the Fastify server with a file size limit, enabling file upload support for endpoints. (`k8s-service/src/index.ts`) [[1]](diffhunk://#diff-03026c463ff5c0d71d08d4fc9d09d32950a2df713172dd0cf3134c8774fb9127R3) [[2]](diffhunk://#diff-03026c463ff5c0d71d08d4fc9d09d32950a2df713172dd0cf3134c8774fb9127R27-R32)

**Bot deployment API and configuration refactor:**

* Refactored the `deployBot` controller to parse multipart form data, extract fields and uploaded zip files, and validate required fields (`name`, `language`, `version`). (`k8s-service/src/controllers/botController.ts`)
* Changed bot configuration and deployment request types to use `language`, `version`, and an array of environment variables (`EnvVar[]`) instead of `type`, `token`, and resource/replica fields. (`k8s-service/src/types/bot.ts`) [[1]](diffhunk://#diff-618a932d22faeffd58fc16e1a74a38d0a16cc1124096479d46441e034f11c90eR16-R34) [[2]](diffhunk://#diff-618a932d22faeffd58fc16e1a74a38d0a16cc1124096479d46441e034f11c90eL55-R52)
* Updated deployment manifest creation to use new labels (`bot-language`, `bot-version`) and simplified environment variable handling. Also, deployment replicas are now always set to 1. (`k8s-service/src/services/botDeploymentService.ts`) [[1]](diffhunk://#diff-754f4aa242fea2970db457b8b0160bd9870f88952280bb7de69621079e835249L20-R30) [[2]](diffhunk://#diff-754f4aa242fea2970db457b8b0160bd9870f88952280bb7de69621079e835249L50-R46) [[3]](diffhunk://#diff-754f4aa242fea2970db457b8b0160bd9870f88952280bb7de69621079e835249L119-R116)