### PR TITLE
Bugfix/fix docker image pull error

### DIFF
--- a/client/src/component/createbot/CommandInput.tsx
+++ b/client/src/component/createbot/CommandInput.tsx
@@ -1,0 +1,32 @@
+interface CommandInputProps {
+  command: string;
+  onCommandChange: (command: string) => void;
+}
+
+export default function CommandInput({ command, onCommandChange }: CommandInputProps) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-white text-sm font-medium mb-2">
+          Commande de démarrage
+        </label>
+        <p className="text-slate-400 text-sm mb-3">
+          Spécifiez la commande pour démarrer votre bot (ex: node index.js, python main.py)
+        </p>
+        <input
+          type="text"
+          value={command}
+          onChange={(e) => onCommandChange(e.target.value)}
+          className="w-full bg-slate-900 border border-slate-700 text-white px-4 py-3 rounded-lg focus:outline-none focus:border-purple-500 transition-colors font-mono"
+          placeholder="node index.js"
+        />
+      </div>
+      <div className="bg-slate-900/50 border border-slate-700/50 rounded-lg p-4">
+        <p className="text-slate-400 text-sm">
+          <span className="text-purple-400 font-semibold">Note :</span> Si aucune commande n'est spécifiée,
+          le conteneur restera actif sans exécuter de code.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/page/CreateBot.tsx
+++ b/client/src/page/CreateBot.tsx
@@ -6,6 +6,7 @@ import DashboardLayout from '../component/dashboard/DashboardLayout';
 import StepIndicator from '../component/createbot/StepIndicator';
 import LanguageSelector from '../component/createbot/LanguageSelector';
 import FileUploader from '../component/createbot/FileUploader';
+import CommandInput from '../component/createbot/CommandInput';
 import EnvVarEditor from '../component/createbot/EnvVarEditor';
 import DeploymentSummary from '../component/createbot/DeploymentSummary';
 import { botService, type EnvVar } from '../services/botService';
@@ -20,9 +21,10 @@ export default function CreateBot() {
   const [language, setLanguage] = useState('nodejs');
   const [version, setVersion] = useState('LTS');
   const [zipFile, setZipFile] = useState<File | null>(null);
+  const [startCommand, setStartCommand] = useState('');
   const [envVars, setEnvVars] = useState<EnvVar[]>([]);
 
-  const steps = ['Configuration', 'Fichiers', 'Variables', 'Récapitulatif'];
+  const steps = ['Configuration', 'Fichiers', 'Commande', 'Variables', 'Récapitulatif'];
 
   const handleNext = () => {
     if (currentStep === 1 && !name.trim()) {
@@ -50,6 +52,7 @@ export default function CreateBot() {
         language,
         version,
         zipFile,
+        startCommand: startCommand.trim() || undefined,
         envVars: validEnvVars,
       });
 
@@ -89,9 +92,12 @@ export default function CreateBot() {
         return <FileUploader zipFile={zipFile} onFileChange={setZipFile} />;
 
       case 3:
-        return <EnvVarEditor envVars={envVars} onEnvVarsChange={setEnvVars} />;
+        return <CommandInput command={startCommand} onCommandChange={setStartCommand} />;
 
       case 4:
+        return <EnvVarEditor envVars={envVars} onEnvVarsChange={setEnvVars} />;
+
+      case 5:
         return (
           <DeploymentSummary
             name={name}

--- a/client/src/services/botService.ts
+++ b/client/src/services/botService.ts
@@ -22,6 +22,7 @@ export interface CreateBotRequest {
   version: string;
   zipFile: File | null;
   envVars: EnvVar[];
+  startCommand?: string;
 }
 
 export interface BotStats {
@@ -52,6 +53,10 @@ export const botService = {
 
     if (data.zipFile) {
       formData.append('zipFile', data.zipFile);
+    }
+
+    if (data.startCommand) {
+      formData.append('startCommand', data.startCommand);
     }
 
     formData.append('envVars', JSON.stringify(data.envVars));

--- a/k8s-service/src/controllers/botController.ts
+++ b/k8s-service/src/controllers/botController.ts
@@ -1,6 +1,7 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { BotDeploymentService } from '../services/botDeploymentService';
 import { BotScaleRequest, EnvVar } from '../types/bot';
+import { getDockerImage } from '../utils/dockerImageMapper';
 
 const botService = new BotDeploymentService();
 
@@ -44,7 +45,7 @@ export const deployBot = async (
       language: fields.language,
       version: fields.version,
       env: envVars,
-      image: `${fields.language}:${fields.version}`,
+      image: getDockerImage(fields.language, fields.version),
     });
 
     reply.status(201).send(bot);

--- a/k8s-service/src/controllers/botController.ts
+++ b/k8s-service/src/controllers/botController.ts
@@ -46,6 +46,7 @@ export const deployBot = async (
       version: fields.version,
       env: envVars,
       image: getDockerImage(fields.language, fields.version),
+      startCommand: fields.startCommand,
     });
 
     reply.status(201).send(bot);

--- a/k8s-service/src/services/botDeploymentService.ts
+++ b/k8s-service/src/services/botDeploymentService.ts
@@ -30,6 +30,17 @@ export class BotDeploymentService {
         : [],
     };
 
+    if (config.startCommand) {
+      const commandParts = config.startCommand.trim().split(/\s+/);
+      container.command = [commandParts[0]];
+      if (commandParts.length > 1) {
+        container.args = commandParts.slice(1);
+      }
+    } else {
+      container.command = ['tail'];
+      container.args = ['-f', '/dev/null'];
+    }
+
     if (config.port) {
       container.ports = [{ containerPort: config.port }];
     }

--- a/k8s-service/src/types/bot.ts
+++ b/k8s-service/src/types/bot.ts
@@ -23,6 +23,7 @@ export interface BotConfig {
   language: string;
   version: string;
   image: string;
+  startCommand?: string;
   env?: EnvVar[];
   port?: number;
 }

--- a/k8s-service/src/types/k8s.ts
+++ b/k8s-service/src/types/k8s.ts
@@ -34,6 +34,8 @@ export interface Pod extends K8sResource {
 export interface Container {
   name: string;
   image: string;
+  command?: string[];
+  args?: string[];
   ports?: Array<{
     containerPort: number;
     protocol?: string;

--- a/k8s-service/src/utils/dockerImageMapper.ts
+++ b/k8s-service/src/utils/dockerImageMapper.ts
@@ -1,0 +1,16 @@
+interface ImageMapping {
+  [key: string]: string;
+}
+
+const languageToDockerImage: ImageMapping = {
+  nodejs: 'node',
+  python: 'python',
+  go: 'golang',
+  rust: 'rust',
+};
+
+export function getDockerImage(language: string, version: string): string {
+  const imageName = languageToDockerImage[language] || language;
+  const imageVersion = version.toLowerCase();
+  return `${imageName}:${imageVersion}`;
+}


### PR DESCRIPTION
This pull request introduces support for specifying a custom start command when deploying a bot, allowing users to define how their bot should be launched in the container. The implementation covers both the frontend and backend, ensuring the command is collected, validated, and passed through to the deployment service, which sets up the container accordingly. Additionally, a utility is added to map bot language and version to the correct Docker image.

**Frontend changes:**

* Added a new `CommandInput` component for users to enter the bot start command, including help text and notes about default behavior. (`client/src/component/createbot/CommandInput.tsx`)
* Updated the bot creation flow to include the command step and pass the entered command to the backend. (`client/src/page/CreateBot.tsx`, `client/src/services/botService.ts`) [[1]](diffhunk://#diff-b95b7d53d24ffc14e4d311a197eb5ba93df352a7ef26df08a45ad95dfee362bfR9) [[2]](diffhunk://#diff-b95b7d53d24ffc14e4d311a197eb5ba93df352a7ef26df08a45ad95dfee362bfR24-R27) [[3]](diffhunk://#diff-b95b7d53d24ffc14e4d311a197eb5ba93df352a7ef26df08a45ad95dfee362bfR55) [[4]](diffhunk://#diff-b95b7d53d24ffc14e4d311a197eb5ba93df352a7ef26df08a45ad95dfee362bfL92-R100) [[5]](diffhunk://#diff-eecb2d0cb4a091fb9df4865d4fc2788b272ceff3b6bc0f9a5a3eae7ce1190330R25) [[6]](diffhunk://#diff-eecb2d0cb4a091fb9df4865d4fc2788b272ceff3b6bc0f9a5a3eae7ce1190330R58-R61)

**Backend changes:**

* Extended the bot deployment API and types to accept and forward the start command. (`k8s-service/src/controllers/botController.ts`, `k8s-service/src/types/bot.ts`) [[1]](diffhunk://#diff-a409162039fba43db28723592beb23de32562cc70f8f379eab97c074c1e2db82R4) [[2]](diffhunk://#diff-a409162039fba43db28723592beb23de32562cc70f8f379eab97c074c1e2db82L47-R49) [[3]](diffhunk://#diff-618a932d22faeffd58fc16e1a74a38d0a16cc1124096479d46441e034f11c90eR26)
* Modified the deployment logic to set the container's `command` and `args` fields based on the provided start command, or use a default idle command if none is specified. (`k8s-service/src/services/botDeploymentService.ts`, `k8s-service/src/types/k8s.ts`) [[1]](diffhunk://#diff-754f4aa242fea2970db457b8b0160bd9870f88952280bb7de69621079e835249R33-R43) [[2]](diffhunk://#diff-465a3a67bb5e72458ea8c3c1f51d36a1312c11baef3035388eee03c802e92bc3R37-R38)

**Utility addition:**

* Added a `getDockerImage` utility to map bot language and version to the appropriate Docker image name. (`k8s-service/src/utils/dockerImageMapper.ts`)