### PR TITLE
Fix docker image pull error

### DIFF
--- a/client/src/component/createbot/DeploymentSummary.tsx
+++ b/client/src/component/createbot/DeploymentSummary.tsx
@@ -1,4 +1,4 @@
-import { FaNodeJs, FaPython, FaFileArchive, FaKey } from 'react-icons/fa';
+import { FaNodeJs, FaPython, FaFileArchive, FaKey, FaTerminal } from 'react-icons/fa';
 import { SiGo, SiRust } from 'react-icons/si';
 import type { EnvVar } from '../../services/botService';
 
@@ -7,6 +7,7 @@ interface DeploymentSummaryProps {
   language: string;
   version: string;
   zipFile: File | null;
+  startCommand?: string;
   envVars: EnvVar[];
 }
 
@@ -15,6 +16,7 @@ export default function DeploymentSummary({
   language,
   version,
   zipFile,
+  startCommand,
   envVars,
 }: DeploymentSummaryProps) {
   const getLanguageIcon = () => {
@@ -99,6 +101,18 @@ export default function DeploymentSummary({
             <p className="text-slate-500 text-sm">Aucun fichier</p>
           )}
         </div>
+
+        {startCommand && (
+          <div className="border-t border-slate-700 pt-6">
+            <div className="flex items-center gap-2 mb-3">
+              <FaTerminal className="text-slate-400" />
+              <p className="text-slate-400 text-sm">Commande de démarrage</p>
+            </div>
+            <div className="bg-slate-800 rounded-lg p-4">
+              <p className="text-purple-400 font-mono text-sm">{startCommand}</p>
+            </div>
+          </div>
+        )}
 
         <div className="border-t border-slate-700 pt-6">
           <div className="flex items-center gap-2 mb-3">

--- a/client/src/page/CreateBot.tsx
+++ b/client/src/page/CreateBot.tsx
@@ -104,6 +104,7 @@ export default function CreateBot() {
             language={language}
             version={version}
             zipFile={zipFile}
+            startCommand={startCommand}
             envVars={envVars}
           />
         );

--- a/k8s-service/src/controllers/botController.ts
+++ b/k8s-service/src/controllers/botController.ts
@@ -40,6 +40,11 @@ export const deployBot = async (
       }
     }
 
+    let zipFileBase64: string | undefined;
+    if (zipFile && zipFile.length > 0) {
+      zipFileBase64 = zipFile.toString('base64');
+    }
+
     const bot = await botService.deployBot({
       name: fields.name,
       language: fields.language,
@@ -47,6 +52,7 @@ export const deployBot = async (
       env: envVars,
       image: getDockerImage(fields.language, fields.version),
       startCommand: fields.startCommand,
+      zipFileBase64,
     });
 
     reply.status(201).send(bot);

--- a/k8s-service/src/services/botDeploymentService.ts
+++ b/k8s-service/src/services/botDeploymentService.ts
@@ -39,9 +39,20 @@ export class BotDeploymentService {
 
       initContainers.push({
         name: 'unzip-code',
-        image: 'busybox:latest',
+        image: 'alpine:latest',
         command: ['sh', '-c'],
-        args: ['unzip -o /zip/bot.zip -d /app && chmod -R 755 /app'],
+        args: [
+          'echo "Installing unzip..." && ' +
+          'apk add --no-cache unzip && ' +
+          'echo "Checking /zip content..." && ' +
+          'ls -la /zip && ' +
+          'echo "Unzipping bot.zip..." && ' +
+          'unzip -o /zip/bot.zip -d /app && ' +
+          'echo "Checking /app content..." && ' +
+          'ls -la /app && ' +
+          'chmod -R 755 /app && ' +
+          'echo "Init container completed successfully!"'
+        ],
         volumeMounts: [
           { name: 'bot-zip', mountPath: '/zip', readOnly: true },
           { name: 'bot-code', mountPath: '/app' },

--- a/k8s-service/src/services/botDeploymentService.ts
+++ b/k8s-service/src/services/botDeploymentService.ts
@@ -46,9 +46,19 @@ export class BotDeploymentService {
           'apk add --no-cache unzip && ' +
           'echo "Checking /zip content..." && ' +
           'ls -la /zip && ' +
-          'echo "Unzipping bot.zip..." && ' +
-          'unzip -o /zip/bot.zip -d /app && ' +
-          'echo "Checking /app content..." && ' +
+          'echo "Unzipping bot.zip to /tmp..." && ' +
+          'unzip -o /zip/bot.zip -d /tmp && ' +
+          'echo "Checking /tmp content..." && ' +
+          'ls -la /tmp && ' +
+          'echo "Moving files to /app..." && ' +
+          'if [ $(ls -A /tmp | wc -l) -eq 1 ] && [ -d "/tmp/$(ls /tmp)" ]; then ' +
+          '  echo "Single directory detected, moving contents up one level..."; ' +
+          '  mv /tmp/*/* /app/ && rm -rf /tmp/*; ' +
+          'else ' +
+          '  echo "Multiple files/directories detected, moving all to /app..."; ' +
+          '  mv /tmp/* /app/; ' +
+          'fi && ' +
+          'echo "Checking final /app content..." && ' +
           'ls -la /app && ' +
           'chmod -R 755 /app && ' +
           'echo "Init container completed successfully!"'

--- a/k8s-service/src/services/botDeploymentService.ts
+++ b/k8s-service/src/services/botDeploymentService.ts
@@ -89,7 +89,7 @@ export class BotDeploymentService {
     if (config.startCommand) {
       const commandParts = config.startCommand.trim().split(/\s+/);
       container.command = ['sh', '-c'];
-      container.args = [`cd /app && ${config.startCommand}`];
+      container.args = [`cd /app && npm install && ${config.startCommand}`];
     } else {
       container.command = ['tail'];
       container.args = ['-f', '/dev/null'];

--- a/k8s-service/src/services/k8sClient.ts
+++ b/k8s-service/src/services/k8sClient.ts
@@ -6,6 +6,7 @@ import {
   Deployment,
   Service,
   Namespace,
+  ConfigMap,
   K8sList,
   K8sResource,
 } from '../types/k8s';
@@ -130,6 +131,20 @@ export class K8sClient {
     const params = tailLines ? { tailLines: tailLines.toString() } : {};
     const response = await this.client.get(`/api/v1/namespaces/${namespace}/pods/${name}/log`, { params });
     return response.data;
+  }
+
+  async createConfigMap(configMap: ConfigMap, namespace: string = 'default'): Promise<ConfigMap> {
+    const response = await this.client.post(`/api/v1/namespaces/${namespace}/configmaps`, configMap);
+    return response.data;
+  }
+
+  async getConfigMap(name: string, namespace: string = 'default'): Promise<ConfigMap> {
+    const response = await this.client.get(`/api/v1/namespaces/${namespace}/configmaps/${name}`);
+    return response.data;
+  }
+
+  async deleteConfigMap(name: string, namespace: string = 'default'): Promise<void> {
+    await this.client.delete(`/api/v1/namespaces/${namespace}/configmaps/${name}`);
   }
 
   async healthCheck(): Promise<boolean> {

--- a/k8s-service/src/types/bot.ts
+++ b/k8s-service/src/types/bot.ts
@@ -24,6 +24,7 @@ export interface BotConfig {
   version: string;
   image: string;
   startCommand?: string;
+  zipFileBase64?: string;
   env?: EnvVar[];
   port?: number;
 }

--- a/k8s-service/src/types/k8s.ts
+++ b/k8s-service/src/types/k8s.ts
@@ -15,6 +15,8 @@ export interface Pod extends K8sResource {
   kind: 'Pod';
   spec: {
     containers: Container[];
+    initContainers?: Container[];
+    volumes?: Volume[];
     restartPolicy?: string;
     nodeSelector?: Record<string, string>;
   };
@@ -45,6 +47,7 @@ export interface Container {
     value?: string;
     valueFrom?: any;
   }>;
+  volumeMounts?: VolumeMount[];
   resources?: {
     limits?: Record<string, string>;
     requests?: Record<string, string>;
@@ -64,6 +67,8 @@ export interface Deployment extends K8sResource {
       };
       spec: {
         containers: Container[];
+        initContainers?: Container[];
+        volumes?: Volume[];
       };
     };
   };
@@ -102,6 +107,31 @@ export interface Namespace extends K8sResource {
   status?: {
     phase: string;
   };
+}
+
+export interface ConfigMap extends K8sResource {
+  kind: 'ConfigMap';
+  data?: Record<string, string>;
+  binaryData?: Record<string, string>;
+}
+
+export interface Volume {
+  name: string;
+  emptyDir?: Record<string, any>;
+  configMap?: {
+    name: string;
+    items?: Array<{
+      key: string;
+      path: string;
+    }>;
+  };
+}
+
+export interface VolumeMount {
+  name: string;
+  mountPath: string;
+  subPath?: string;
+  readOnly?: boolean;
 }
 
 export interface K8sList<T extends K8sResource> {


### PR DESCRIPTION
This pull request introduces support for deploying bots from uploaded zip files, enhancing the deployment pipeline to handle custom code archives and start commands. The changes span both the frontend and backend, adding new Kubernetes resource handling and updating deployment logic to extract and run code from zip files.

**Backend: Zip file support and deployment enhancements**
* Added support for passing a bot code zip file as a base64 string in the deployment API and storing it in a Kubernetes `ConfigMap`. This enables users to upload their bot code as a zip file for deployment. [[1]](diffhunk://#diff-a409162039fba43db28723592beb23de32562cc70f8f379eab97c074c1e2db82R43-R55) [[2]](diffhunk://#diff-618a932d22faeffd58fc16e1a74a38d0a16cc1124096479d46441e034f11c90eR27) [[3]](diffhunk://#diff-754f4aa242fea2970db457b8b0160bd9870f88952280bb7de69621079e835249R201-R220)
* Updated the deployment logic to mount the uploaded zip file and extract its contents using an init container, then run the bot from the extracted code directory. This includes new volume and volume mount definitions, and ensures the working directory is set appropriately. [[1]](diffhunk://#diff-754f4aa242fea2970db457b8b0160bd9870f88952280bb7de69621079e835249R25-R72) [[2]](diffhunk://#diff-754f4aa242fea2970db457b8b0160bd9870f88952280bb7de69621079e835249R81-R92) [[3]](diffhunk://#diff-754f4aa242fea2970db457b8b0160bd9870f88952280bb7de69621079e835249R121-R122) [[4]](diffhunk://#diff-465a3a67bb5e72458ea8c3c1f51d36a1312c11baef3035388eee03c802e92bc3R18-R19) [[5]](diffhunk://#diff-465a3a67bb5e72458ea8c3c1f51d36a1312c11baef3035388eee03c802e92bc3R50) [[6]](diffhunk://#diff-465a3a67bb5e72458ea8c3c1f51d36a1312c11baef3035388eee03c802e92bc3R70-R71) [[7]](diffhunk://#diff-465a3a67bb5e72458ea8c3c1f51d36a1312c11baef3035388eee03c802e92bc3R112-R136)
* Implemented cleanup logic to delete the associated `ConfigMap` when a bot is deleted, preventing orphaned resources.

**Backend: Kubernetes client extensions**
* Added methods to the Kubernetes client for creating, retrieving, and deleting `ConfigMap` resources, supporting the new zip file deployment flow. [[1]](diffhunk://#diff-159ccad2e095bf4d9d64ad730a3a6a992f3358b38c0352d5a82c4a95e5c4c574R9) [[2]](diffhunk://#diff-159ccad2e095bf4d9d64ad730a3a6a992f3358b38c0352d5a82c4a95e5c4c574R136-R149)

**Frontend: Deployment summary and start command**
* Updated the deployment summary UI to display the start command and support the new zip file upload, improving clarity for users deploying custom bots. [[1]](diffhunk://#diff-ce4e891a974f697f2c25bb5a27311ada1702bb6cee0411859f25d1781d612170L1-R1) [[2]](diffhunk://#diff-ce4e891a974f697f2c25bb5a27311ada1702bb6cee0411859f25d1781d612170R10) [[3]](diffhunk://#diff-ce4e891a974f697f2c25bb5a27311ada1702bb6cee0411859f25d1781d612170R19) [[4]](diffhunk://#diff-ce4e891a974f697f2c25bb5a27311ada1702bb6cee0411859f25d1781d612170R105-R116) [[5]](diffhunk://#diff-b95b7d53d24ffc14e4d311a197eb5ba93df352a7ef26df08a45ad95dfee362bfR107)