### PR TITLE
Feature/add user roles

### DIFF
--- a/auth-service/src/services/AuthService.ts
+++ b/auth-service/src/services/AuthService.ts
@@ -5,7 +5,7 @@ import * as crypto from 'crypto';
 import axios from 'axios';
 import * as speakeasy from 'speakeasy';
 import * as QRCode from 'qrcode';
-import { User } from '../entities/User';
+import { User, UserRole } from '../entities/User';
 import { AppDataSource } from '../config/database';
 import { sendWelcomeEmail, sendPasswordResetEmail } from '../grpc/mailGrpcClient';
 
@@ -37,7 +37,7 @@ export class AuthService {
       const user = this.userRepository.create({
         email,
         password: hashedPassword,
-        role: email === 'dilgopierre@gmail.com' ? 'admin' : 'user',
+        role: email === 'dilgopierre@gmail.com' ? UserRole.ADMIN : UserRole.USER,
       });
 
       console.log('[AuthService] Saving user to database');
@@ -331,6 +331,7 @@ export class AuthService {
       discordUsername,
       discordAvatar,
       email,
+      role: email === 'dilgopierre@gmail.com' ? UserRole.ADMIN : UserRole.USER,
     });
 
     const savedUser = await this.userRepository.save(user);


### PR DESCRIPTION
This pull request introduces a role assignment feature to the user creation logic in the `AuthService`. The main change is that users with the email `dilgopierre@gmail.com` are automatically assigned the `ADMIN` role, while all other users are assigned the `USER` role. This ensures that the designated email receives administrative privileges upon registration.

**User Role Assignment:**

* Updated user creation logic in `AuthService` to assign `UserRole.ADMIN` to users with the email `dilgopierre@gmail.com`, and `UserRole.USER` to all other users. (`auth-service/src/services/AuthService.ts`) [[1]](diffhunk://#diff-52b5806293d3ec24b6969e4870627e71d8140664ea566a26f1aa8d52aaa64ffaR40) [[2]](diffhunk://#diff-52b5806293d3ec24b6969e4870627e71d8140664ea566a26f1aa8d52aaa64ffaR334)
* Imported `UserRole` from `User` entity to support role assignment during user creation. (`auth-service/src/services/AuthService.ts`)