### PR TITLE
chore: Update GitHub Actions workflow to enable BuildKit registry compression

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ jobs:
       REGISTRY: docker.hostyourbot.app
       REGISTRY_USERNAME: admin
       IMAGE_TAG: ${{ github.sha }}
+      BUILDKIT_REGISTRY_COMPRESSION: gzip
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
- Added BUILDKIT_REGISTRY_COMPRESSION environment variable set to gzip in the deploy.yml workflow to optimize Docker image builds.