### PR TITLE
chore: Update GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ jobs:
       REGISTRY: docker.hostyourbot.app
       REGISTRY_USERNAME: admin
       IMAGE_TAG: ${{ github.sha }}
+      BUILDKIT_REGISTRY_COMPRESSION: gzip
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
This pull request introduces a minor configuration change to the deployment workflow. The main update is the addition of a new environment variable to optimize Docker image compression during builds.

* Deployment workflow configuration: Added the `BUILDKIT_REGISTRY_COMPRESSION: gzip` environment variable to `.github/workflows/deploy.yml` to enable gzip compression for Docker images when pushing to the registry.