### PR TITLE
chore: Refactor API URL resolution to use dynamic fallback

### DIFF
--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -28,13 +28,29 @@ const resolveUrl = (base: string, path: string) => {
   }
 };
 
+const resolveDefaultUrl = (path: string, fallback: string) => {
+  if (!import.meta.env.DEV && typeof window !== 'undefined') {
+    return resolveUrl(window.location.origin, path);
+  }
+  return fallback;
+};
+
 const authConfig = createApiConfig(
   import.meta.env.VITE_AUTH_API_URL ?? import.meta.env.VITE_API_URL,
-  'http://localhost:3001'
+  resolveDefaultUrl('/api/auth', 'http://localhost:3001')
 );
-const k8sConfig = createApiConfig(import.meta.env.VITE_K8S_API_URL, 'http://localhost:3003');
-const logsConfig = createApiConfig(import.meta.env.VITE_LOGS_API_URL, 'http://localhost:3002');
-const builderConfig = createApiConfig(import.meta.env.VITE_BUILDER_API_URL, 'http://localhost:3004');
+const k8sConfig = createApiConfig(
+  import.meta.env.VITE_K8S_API_URL,
+  resolveDefaultUrl('/api/k8s', 'http://localhost:3003')
+);
+const logsConfig = createApiConfig(
+  import.meta.env.VITE_LOGS_API_URL,
+  resolveDefaultUrl('/api/logs', 'http://localhost:3002')
+);
+const builderConfig = createApiConfig(
+  import.meta.env.VITE_BUILDER_API_URL,
+  resolveDefaultUrl('/api/builder', 'http://localhost:3004')
+);
 
 export const resolveAuthUrl = (path: string) => resolveUrl(authConfig.raw, path);
 export const resolveK8sUrl = (path: string) => resolveUrl(k8sConfig.raw, path);


### PR DESCRIPTION
This pull request updates the API configuration logic in `client/src/services/api.ts` to better handle environment-specific URLs and fallback values. The main improvement is the introduction of a helper function to resolve default URLs based on the current environment, which increases flexibility and reliability when switching between development and production.

API configuration improvements:

* Added the `resolveDefaultUrl` function to generate base URLs dynamically depending on whether the code is running in development or production, using the browser's origin in production and a fallback in development.
* Updated the creation of `authConfig`, `k8sConfig`, `logsConfig`, and `builderConfig` to use `resolveDefaultUrl` for their fallback values, replacing hardcoded localhost URLs with dynamic resolution.