### PR TITLE
chore: Implement health checks for PostgreSQL

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,6 +8,11 @@ services:
       - POSTGRES_PASSWORD=${DB_PASSWORD}
     volumes:
       - postgres-auth-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_NAME}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     restart: unless-stopped
 
   auth-service:
@@ -29,7 +34,8 @@ services:
       - LOGS_GRPC_URL=logs-service:50052
       - MAIL_GRPC_URL=mail-service:50053
     depends_on:
-      - postgres-auth
+      postgres-auth:
+        condition: service_healthy
     restart: unless-stopped
 
   logs-service:


### PR DESCRIPTION
This pull request introduces improvements to the database connection logic in `auth-service` and enhances the reliability of service startup in the production Docker Compose configuration. The main changes include adding retry logic for database initialization and configuring health checks for the PostgreSQL service to ensure dependent services only start when the database is healthy.

**Database Connection Reliability:**

* Added a `connectWithRetry` function in `auth-service/src/index.ts` to retry database initialization up to 10 times with a delay, improving resilience against transient connection issues. [[1]](diffhunk://#diff-68b3c78b8aa36414600857e510d9999f21649086054fe9a9ce1c7378b93b3b7cL60-R63) [[2]](diffhunk://#diff-68b3c78b8aa36414600857e510d9999f21649086054fe9a9ce1c7378b93b3b7cL70-R86)

**Docker Compose Health Checks and Dependency Management:**

* Added a health check to the `postgres-auth` service in `docker-compose.prod.yml` to verify database readiness before starting dependent services.
* Updated the `auth-service` dependency on `postgres-auth` to use the `service_healthy` condition, ensuring it only starts after the database passes its health check.