### PR TITLE
chore: Update Nginx gateway configuration to remove trailing slashes …

### DIFF
--- a/nginx/gateway.conf
+++ b/nginx/gateway.conf
@@ -28,7 +28,7 @@ http {
     }
 
     location /api/auth/ {
-      proxy_pass http://auth_service/;
+      proxy_pass http://auth_service;
       proxy_http_version 1.1;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -42,7 +42,7 @@ http {
     }
 
     location /api/logs/ {
-      proxy_pass http://logs_service/;
+      proxy_pass http://logs_service;
       proxy_http_version 1.1;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -56,7 +56,7 @@ http {
     }
 
     location /api/k8s/ {
-      proxy_pass http://k8s_service/;
+      proxy_pass http://k8s_service;
       proxy_http_version 1.1;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
…from proxy_pass

- Modified the proxy_pass directives in nginx/gateway.conf for auth_service, logs_service, and k8s_service to remove trailing slashes, ensuring proper request forwarding without unintended path alterations.