### PR TITLE
chore: Update Nginx gateway configuration

### DIFF
--- a/nginx/gateway.conf
+++ b/nginx/gateway.conf
@@ -28,7 +28,7 @@ http {
     }
 
     location /api/auth/ {
-      proxy_pass http://auth_service/;
+      proxy_pass http://auth_service;
       proxy_http_version 1.1;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -42,7 +42,7 @@ http {
     }
 
     location /api/logs/ {
-      proxy_pass http://logs_service/;
+      proxy_pass http://logs_service;
       proxy_http_version 1.1;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -56,7 +56,7 @@ http {
     }
 
     location /api/k8s/ {
-      proxy_pass http://k8s_service/;
+      proxy_pass http://k8s_service;
       proxy_http_version 1.1;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
This pull request makes a minor update to the `nginx/gateway.conf` configuration file. Specifically, it removes the trailing slashes from the `proxy_pass` directives for several API service locations. This change ensures that NGINX forwards requests to the upstream services without altering the request URI path unexpectedly.

- NGINX configuration updates:
  * Removed trailing slashes from `proxy_pass` directives for `/api/auth/`, `/api/logs/`, and `/api/k8s/` locations in `nginx/gateway.conf` to ensure correct request forwarding. [[1]](diffhunk://#diff-bc93f9f0e155ee7317793506430036f9c8a1a340dc1dab9e89cabe5af9e18edaL31-R31) [[2]](diffhunk://#diff-bc93f9f0e155ee7317793506430036f9c8a1a340dc1dab9e89cabe5af9e18edaL45-R45) [[3]](diffhunk://#diff-bc93f9f0e155ee7317793506430036f9c8a1a340dc1dab9e89cabe5af9e18edaL59-R59)