### PR TITLE
chore: Execute database migrations on service startup

### DIFF
--- a/auth-service/src/index.ts
+++ b/auth-service/src/index.ts
@@ -63,6 +63,9 @@ const connectWithRetry = async (retries = 10, delay = 5000): Promise<void> => {
       await AppDataSource.initialize();
       console.log('Database connected successfully');
 
+      await AppDataSource.runMigrations();
+      console.log('Migrations executed successfully');
+
       initLogsGrpcClient();
       initMailGrpcClient();
 


### PR DESCRIPTION
- Added a call to run migrations after establishing a database connection in auth-service's index.ts, ensuring the database schema is up-to-date during service initialization.