### PR TITLE
chore: Execute database migrations on service startup

### DIFF
--- a/auth-service/src/index.ts
+++ b/auth-service/src/index.ts
@@ -63,6 +63,9 @@ const connectWithRetry = async (retries = 10, delay = 5000): Promise<void> => {
       await AppDataSource.initialize();
       console.log('Database connected successfully');
 
+      await AppDataSource.runMigrations();
+      console.log('Migrations executed successfully');
+
       initLogsGrpcClient();
       initMailGrpcClient();
 


### PR DESCRIPTION
This pull request makes a small but important improvement to the database startup logic. Now, after establishing a database connection, the application will automatically run any pending migrations to ensure the schema is up to date before proceeding.

- Automatically runs database migrations after a successful connection by calling `AppDataSource.runMigrations()` in `auth-service/src/index.ts`.