### PR TITLE
chore: Add initial database migration for users and subscription plans

### DIFF
--- a/auth-service/src/index.ts
+++ b/auth-service/src/index.ts
@@ -75,6 +75,12 @@ const connectWithRetry = async (retries = 10, delay = 5000): Promise<void> => {
       return;
     } catch (error) {
       console.error(`Database connection attempt ${i + 1}/${retries} failed:`, error);
+
+      if (AppDataSource.isInitialized) {
+        await AppDataSource.destroy();
+        console.log('Database connection destroyed for retry');
+      }
+
       if (i < retries - 1) {
         console.log(`Retrying in ${delay / 1000} seconds...`);
         await new Promise(resolve => setTimeout(resolve, delay));

--- a/auth-service/src/migrations/1728440000000-CreateInitialTables.ts
+++ b/auth-service/src/migrations/1728440000000-CreateInitialTables.ts
@@ -1,0 +1,112 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateInitialTables1728440000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'users',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'email',
+            type: 'varchar',
+            isNullable: true,
+            isUnique: true,
+          },
+          {
+            name: 'password',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'subscription_plans',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+            isUnique: true,
+          },
+          {
+            name: 'displayName',
+            type: 'varchar',
+          },
+          {
+            name: 'description',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'price',
+            type: 'decimal',
+            precision: 10,
+            scale: 2,
+            default: 0,
+          },
+          {
+            name: 'billingPeriod',
+            type: 'varchar',
+            default: "'monthly'",
+          },
+          {
+            name: 'features',
+            type: 'jsonb',
+          },
+          {
+            name: 'isActive',
+            type: 'boolean',
+            default: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true
+    );
+
+    await queryRunner.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('subscription_plans');
+    await queryRunner.dropTable('users');
+  }
+}


### PR DESCRIPTION
- Created a new migration file to establish the 'users' and 'subscription_plans' tables in the database, including necessary fields and constraints.
- Enhanced the database connection logic to destroy the connection if it is already initialized before retrying, improving resilience during connection attempts.