### PR TITLE
chore: Add initial database migration for users and subscription plans

### DIFF
--- a/auth-service/src/index.ts
+++ b/auth-service/src/index.ts
@@ -75,6 +75,12 @@ const connectWithRetry = async (retries = 10, delay = 5000): Promise<void> => {
       return;
     } catch (error) {
       console.error(`Database connection attempt ${i + 1}/${retries} failed:`, error);
+
+      if (AppDataSource.isInitialized) {
+        await AppDataSource.destroy();
+        console.log('Database connection destroyed for retry');
+      }
+
       if (i < retries - 1) {
         console.log(`Retrying in ${delay / 1000} seconds...`);
         await new Promise(resolve => setTimeout(resolve, delay));

--- a/auth-service/src/migrations/1728440000000-CreateInitialTables.ts
+++ b/auth-service/src/migrations/1728440000000-CreateInitialTables.ts
@@ -1,0 +1,112 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateInitialTables1728440000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'users',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'email',
+            type: 'varchar',
+            isNullable: true,
+            isUnique: true,
+          },
+          {
+            name: 'password',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'subscription_plans',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+            isUnique: true,
+          },
+          {
+            name: 'displayName',
+            type: 'varchar',
+          },
+          {
+            name: 'description',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'price',
+            type: 'decimal',
+            precision: 10,
+            scale: 2,
+            default: 0,
+          },
+          {
+            name: 'billingPeriod',
+            type: 'varchar',
+            default: "'monthly'",
+          },
+          {
+            name: 'features',
+            type: 'jsonb',
+          },
+          {
+            name: 'isActive',
+            type: 'boolean',
+            default: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true
+    );
+
+    await queryRunner.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('subscription_plans');
+    await queryRunner.dropTable('users');
+  }
+}


### PR DESCRIPTION
This pull request introduces important improvements to the authentication service, focusing on database reliability and foundational schema setup. The main changes include enhanced handling of database connection retries and the addition of an initial migration to create core tables for users and subscription plans.

**Database reliability improvements:**

* Improved the `connectWithRetry` function in `auth-service/src/index.ts` to destroy the existing database connection before retrying, ensuring clean reconnections and reducing the risk of stale connections.

**Database schema setup:**

* Added a new migration file `auth-service/src/migrations/1728440000000-CreateInitialTables.ts` that creates the `users` and `subscription_plans` tables with appropriate fields, types, and constraints, and ensures the `uuid-ossp` extension is enabled for UUID generation.