### PR TITLE
chore: Add FRONTEND_URL environment variable to production compose file

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,7 @@ services:
       - DISCORD_CLIENT_SECRET=${DISCORD_CLIENT_SECRET}
       - DISCORD_CALLBACK_URL=${DISCORD_CALLBACK_URL}
       - CLIENT_URL=${CLIENT_URL}
+      - FRONTEND_URL=${FRONTEND_URL}
       - LOGS_GRPC_URL=logs-service:50052
       - MAIL_GRPC_URL=mail-service:50053
     depends_on:


### PR DESCRIPTION
- Included FRONTEND_URL in docker-compose.prod.yml to support frontend service configuration in production.
- This addition enhances the application's ability to connect with the frontend, improving overall integration.